### PR TITLE
PDP Discount Badge

### DIFF
--- a/assets/discounted-badge.css
+++ b/assets/discounted-badge.css
@@ -1,0 +1,5 @@
+.discounted-item__old-price {
+    color: rgba(var(--color-foreground), 0.75);
+    font-size: 1.6rem;
+    letter-spacing: 0.07rem;
+  }

--- a/assets/sale-badge.css
+++ b/assets/sale-badge.css
@@ -1,0 +1,19 @@
+.price__badge-sale-percentage {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25em 0.75em;
+  border-radius: 4px;
+  text-transform: uppercase;
+  font-weight: bold;
+}
+
+@keyframes badge-pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+.animate-badge {
+  animation: badge-pulse 2s infinite ease-in-out;
+}

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1465,5 +1465,51 @@
         "default": "scheme-1"
       }
     ]
+  },
+  {
+    "name": "t:settings_schema.on_sale_badge.name",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "show_sale_percentage",
+        "label": "t:settings_schema.on_sale_badge.settings.show_sale_percentage.label",
+        "default": false
+      },
+      {
+        "type": "text",
+        "id": "sale_percentage_text",
+        "label": "t:settings_schema.on_sale_badge.settings.sale_percentage_text.label",
+        "default": "off",
+        "info": "t:settings_schema.on_sale_badge.settings.sale_percentage_text.info"
+      },
+      {
+        "type": "range",
+        "id": "sale_badge_font_size",
+        "min": 12,
+        "max": 24,
+        "step": 1,
+        "unit": "px",
+        "label": "t:settings_schema.on_sale_badge.settings.sale_badge_font_size.label",
+        "default": 14
+      },
+      {
+        "type": "color",
+        "id": "sale_badge_font_color",
+        "label": "t:settings_schema.on_sale_badge.settings.sale_badge_font_color.label",
+        "default": "#FFFFFF"
+      },
+      {
+        "type": "color",
+        "id": "sale_badge_background",
+        "label": "t:settings_schema.on_sale_badge.settings.sale_badge_background.label",
+        "default": "#DE0000"
+      },
+      {
+        "type": "checkbox",
+        "id": "sale_badge_animation",
+        "label": "t:settings_schema.on_sale_badge.settings.sale_badge_animation.label",
+        "default": false
+      }
+    ]
   }
 ]

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -78,7 +78,10 @@
     "total_reviews": "total reviews",
     "star_reviews_info": "{{ rating_value }} out of {{ rating_max }} stars",
     "collapsible_content_title": "Collapsible content",
-    "complementary_products": "Complementary products"
+    "complementary_products": "Complementary products",
+    "sale_badge": {
+      "discount_announcement": "Save {{ savings }}% {{ text }}"
+    }
   },
   "blogs": {
     "article": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -368,6 +368,30 @@
           "label": "Vertical space"
         }
       }
+    },
+    "on_sale_badge": {
+      "name": "On Sale Badge",
+      "settings": {
+        "show_sale_percentage": {
+          "label": "Show discount percentage"
+        },
+        "sale_percentage_text": {
+          "label": "Text after percentage",
+          "info": "Example: Enter 'off' to show '20% off'"
+        },
+        "sale_badge_font_size": {
+          "label": "Badge font size"
+        },
+        "sale_badge_font_color": {
+          "label": "Badge text color"
+        },
+        "sale_badge_background": {
+          "label": "Badge background color"
+        },
+        "sale_badge_animation": {
+          "label": "Enable animation"
+        }
+      }
     }
   },
   "sections": {

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -12,6 +12,9 @@
   Usage:
   {% render 'price', product: product %}
 {% endcomment %}
+
+{{ 'discounted-badge.css' | asset_url | stylesheet_tag }}
+
 {%- liquid
   if use_variant
     assign target = product.selected_or_first_available_variant
@@ -59,6 +62,19 @@
           - div.price__sale: Displayed when a variant is a sale
       {%- endcomment -%}
       <div class="price__regular">
+
+              {% comment %} Find the discounted variant ID in the cart {% endcomment %}
+
+              {% assign in_cart = false %}
+              {% assign cart_item = nil %}
+              {% for item in cart.items %}
+                {% if product.selected_or_first_available_variant.id == item.variant_id %}
+                  {% assign in_cart = true %}
+                  {% assign cart_item = item %}
+                  {% break %}
+                {% endif %}
+              {% endfor %}
+              
         {%- if product.quantity_price_breaks_configured? -%}
           {%- if show_compare_at_price and compare_at_price -%}
             {%- unless product.price_varies == false and product.compare_at_price_varies %}
@@ -84,11 +100,47 @@
             -}}
           </span>
         {%- else -%}
-          <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.regular_price' | t }}</span>
-          <span class="price-item price-item--regular">
-            {{ money_price }}
-          </span>
+          {% if in_cart and cart_item != nil %}
+            <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.regular_price' | t }}</span>
+            <span>
+              <s class="price-item price-item--regular discounted-item__old-price">
+                {% if settings.currency_code_enabled %}
+                  {{ cart_item.original_price | money_with_currency }}
+                {% else %}
+                  {{ cart_item.original_price | money }}
+                {% endif %}
+              </s>
+            </span>
+            <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.sale_price' | t }}</span>
+            <span class="price-item price-item--sale price-item--last">
+              {% if settings.currency_code_enabled %}
+                {{ cart_item.line_price | money_with_currency }}
+              {% else %}
+                {{ cart_item.line_price | money }}
+              {% endif %}
+            </span>
+          {% else %}
+            <span class="visually-hidden visually-hidden--inline">{{ 'products.product.price.regular_price' | t }}</span>
+            <span class="price-item price-item--regular">
+              {{ money_price }}
+            </span>
+          {% endif %}
         {%- endif -%}
+
+
+        {% if in_cart and cart_item != nil %}
+          {% render 'sale-badge',
+            compare_at_price: cart_item.original_price,
+            price: cart_item.line_price,
+            show_percentage: settings.show_sale_percentage,
+            percentage_text: settings.sale_percentage_text,
+            font_size: settings.sale_badge_font_size,
+            font_color: settings.sale_badge_font_color,
+            background_color: settings.sale_badge_background,
+            animate: settings.sale_badge_animation
+          %}
+        {% endif %}
+
       </div>
       <div class="price__sale">
         {%- unless product.price_varies == false and product.compare_at_price_varies %}
@@ -124,10 +176,16 @@
       </small>
     </div>
     {%- if show_badges -%}
-      <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}">
-        {{ 'products.product.on_sale' | t }}
-      </span>
-
+      {% render 'sale-badge',
+        compare_at_price: compare_at_price,
+        price: price,
+        show_percentage: settings.show_sale_percentage,
+        percentage_text: settings.sale_percentage_text,
+        font_size: settings.sale_badge_font_size,
+        font_color: settings.sale_badge_font_color,
+        background_color: settings.sale_badge_background,
+        animate: settings.sale_badge_animation
+      %}
       <span class="badge price__badge-sold-out color-{{ settings.sold_out_badge_color_scheme }}">
         {{ 'products.product.sold_out' | t }}
       </span>

--- a/snippets/sale-badge.liquid
+++ b/snippets/sale-badge.liquid
@@ -1,0 +1,51 @@
+{% comment %}
+  Renders a sale badge with optional percentage discount
+
+  Accepts:
+  - compare_at_price: {Number} Original price (required)
+  - price: {Number} Sale price (required)
+  - show_percentage: {Boolean} Whether to show the percentage discount (optional)
+  - percentage_text: {String} Text to show after the percentage (optional)
+  - font_size: {Number} Font size in pixels (optional)
+  - font_color: {String} Font color (optional)
+  - background_color: {String} Background color (optional)
+  - animate: {Boolean} Whether to enable animation (optional)
+
+  Usage:
+  {% render 'sale-badge',
+    compare_at_price: product.compare_at_price,
+    price: product.price,
+    show_percentage: settings.show_sale_percentage,
+    percentage_text: settings.sale_percentage_text,
+    font_size: settings.sale_badge_font_size,
+    font_color: settings.sale_badge_font_color,
+    background_color: settings.sale_badge_background,
+    animate: settings.sale_badge_animation
+  %}
+{% endcomment %}
+
+{{ 'sale-badge.css' | asset_url | stylesheet_tag }}
+
+{% if compare_at_price > price %}
+  {% assign discount_percentage = compare_at_price | minus: price | times: 100.0 | divided_by: compare_at_price | round -%}
+<span class="price--on-sale"> 
+  <span 
+    class="badge {% if show_percentage %}price__badge-sale-percentage{% if animate %} animate-badge{% endif %}{% else %} price__badge-sale color-{{ settings.sale_badge_color_scheme }}{% endif %}"
+    {% if show_percentage %}
+    style="
+      font-size: {{ font_size }}px; 
+      color: {{ font_color }}; 
+      background-color: {{ background_color }};
+    "
+    {% endif %}
+    role="status"
+    aria-label="{% if show_percentage %}{{ 'accessibility.sale_badge.discount_announcement' | t: savings: discount_percentage, text: percentage_text }}{% else %}{{ 'products.product.on_sale' | t }}{% endif %}"
+  >
+    {% if show_percentage %}
+      {{ discount_percentage }}% {{ percentage_text }}
+    {% else %}
+      {{ 'products.product.on_sale' | t }}
+    {% endif %}
+  </span>
+</span>
+{% endif %}


### PR DESCRIPTION
Created sales-badge.liquid component to improve reusability, handling both compare-at price and discounted price scenarios.

The component includes a dedicated Theme Settings section that allows store admins to:
- Toggle between default badge and the custom badge
- Customize badge UI elements

Note: Currently only supports English and basic accessibility features. Future improvements will focus on internationalization support and enhanced accessibility.